### PR TITLE
RRCF optimization

### DIFF
--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/ForestActor.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/ForestActor.scala
@@ -11,9 +11,11 @@ import io.hydrosphere.serving.tensorflow.tensor.DoubleTensor
 class ForestActor(val forestParams: ForestParams) extends Actor with ActorLogging {
 
   log.info("Warmup state for {} requests", forestParams.warmupPointsNum)
+
   /**
     * State of actor when it actually infers the forest.
     * No state transitions from here.
+    *
     * @param forest forest to infer from
     * @return
     */
@@ -30,6 +32,7 @@ class ForestActor(val forestParams: ForestParams) extends Actor with ActorLoggin
   /**
     * State of actor, when it accumulates points and returns specified constant.
     * Changes context to `infer` when accumulated enough points.
+    *
     * @param buffer buffer with points
     * @return
     */
@@ -39,12 +42,12 @@ class ForestActor(val forestParams: ForestParams) extends Actor with ActorLoggin
       val uuid = UUID.randomUUID()
       log.info(s"[{}] Request recieved during warmup", uuid)
       val newBuffer = buffer :+ datapoint
-      val warmupPercent =  ((newBuffer.length.toDouble / forestParams.warmupPointsNum.toDouble) * 100).formatted("%2.2f%%")
+      val warmupPercent = ((newBuffer.length.toDouble / forestParams.warmupPointsNum.toDouble) * 100).formatted("%2.2f%%")
       log.info(f"[{}] Forest is initializing {}", uuid, warmupPercent)
 
       if (newBuffer.length >= forestParams.warmupPointsNum) {
         log.info(f"[{}] Warmed up", uuid)
-        val forest = new RRCF(forestParams, buffer.toArray)
+        val forest = new RRCF(forestParams, newBuffer.toArray)
         log.info("[{}] Infer state", uuid)
         val score = forest.recieve(datapoint)
         log.info(s"[{}] Response: {}", uuid, score)
@@ -58,6 +61,7 @@ class ForestActor(val forestParams: ForestParams) extends Actor with ActorLoggin
 
   /**
     * Initial state of actor is `warmup`
+    *
     * @return
     */
   override def receive: Receive = warmup(List.empty)

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/ForestService.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/ForestService.scala
@@ -7,9 +7,9 @@ import io.hydrosphere.rrcf.impl.{DataPoint, ForestParams}
 import io.hydrosphere.serving.contract.model_contract.ModelContract
 import io.hydrosphere.serving.contract.model_field.ModelField
 import io.hydrosphere.serving.contract.model_signature.ModelSignature
-import io.hydrosphere.serving.tensorflow.types.DataType
 import io.hydrosphere.serving.tensorflow.api.predict.{PredictRequest, PredictResponse}
 import io.hydrosphere.serving.tensorflow.api.prediction_service.PredictionServiceGrpc.PredictionService
+import io.hydrosphere.serving.tensorflow.types.DataType
 
 import scala.concurrent.Future
 
@@ -17,7 +17,6 @@ class ForestService(
   val forestParams: ForestParams,
   val modelContract: ModelContract
 )(implicit val timeout: Timeout, val actorSystem: ActorSystem) extends PredictionService {
-  import actorSystem._
 
   val signature: ModelSignature = modelContract.signatures.find(_.signatureName == "detect").getOrElse(throw new IllegalArgumentException("Can't find 'detect' signature in contract"))
   val input: ModelField = signature.inputs.find(_.name == "features").getOrElse(throw new IllegalArgumentException("Can't find 'features' input"))

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/DataPoint.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/DataPoint.scala
@@ -9,4 +9,6 @@ case class DataPoint(array: Array[Double]) {
   }
 
   override def toString: String = array.mkString(" ")
+
+  override def hashCode(): Int = java.util.Arrays.hashCode(array)
 }

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/ForestParams.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/ForestParams.scala
@@ -9,17 +9,17 @@ import scala.io.Source
 import scala.util.control.NonFatal
 
 case class ForestParams(
-  treesNum: Int = 5,
-  samplesNum: Int = 100,
-  shingleSize: Int = 4,
-  timeDecay: Long = 10000,
+  treesNum: Int = 300,
+  samplesNum: Int = 300,
+  shingleSize: Int = 2,
+  timeDecay: Long = 1000,
   warmupScore: Double = -1
 ) {
   override def toString: String = {
     s"Number of trees: $treesNum; Samples per tree: $samplesNum; Shingle size: $shingleSize; Time-Decay: $timeDecay"
   }
 
-  def warmupPointsNum = samplesNum * treesNum + shingleSize
+  def warmupPointsNum = samplesNum + shingleSize - 1
 }
 
 object ForestParams {

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCF.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCF.scala
@@ -1,17 +1,19 @@
 package io.hydrosphere.rrcf.impl
 
+import java.io._
 
-class RRCF(val forestParams: ForestParams, initialData: Array[DataPoint]) {
 
-  require(initialData.length >= forestParams.treesNum * forestParams.samplesNum + forestParams.shingleSize - 1)
+class RRCF(val forestParams: ForestParams, val initialData: Array[DataPoint]) {
+
+  require(initialData.length == forestParams.warmupPointsNum)
 
   val trees = new Array[RRCT](forestParams.treesNum)
-  val shingledData: List[DataPoint] = initialData.sliding(forestParams.shingleSize, 1).map(x => DataPoint(x.flatMap(_.array).toArray)).toList
-  val shuffledInitShingles: List[DataPoint] = scala.util.Random.shuffle(shingledData)
+  val shingledData: Array[DataPoint] = initialData.sliding(forestParams.shingleSize, 1).map(x => DataPoint(x.flatMap(_.array))).toArray
+  assert(shingledData.length == forestParams.samplesNum)
+  //  val shuffledInitShingles: List[DataPoint] = scala.util.Random.shuffle(shingledData)
   val shingler = new Shingler(initialData.takeRight(forestParams.shingleSize))
 
-  (0 until forestParams.treesNum).par.foreach(index => trees(index) =
-    new RRCT(shuffledInitShingles.slice(index * forestParams.samplesNum, (index + 1) * forestParams.samplesNum).toArray))
+  (0 until forestParams.treesNum).par.foreach(index => trees(index) = new RRCT(shingledData))
 
   def recieve(dataPoint: DataPoint): Double = {
     val newShingle = shingler.insert(dataPoint)
@@ -19,4 +21,16 @@ class RRCF(val forestParams: ForestParams, initialData: Array[DataPoint]) {
     trees.par.foreach(_.insertDatapoint(newShingle))
     score
   }
+
+  def averageTreeIntersection = {
+    def intersectionRate(tree1: RRCT, tree2: RRCT): Double = {
+      val commonDatapoints: Double = tree1.leafStorage.keySet.intersect(tree2.leafStorage.keySet).size.toDouble
+      commonDatapoints / tree1.leafStorage.keySet.size
+    }
+
+    val intersectionRates = trees.toSeq.combinations(2).map { case Seq(a, b) => intersectionRate(a, b) }
+    intersectionRates.foldLeft((0.0, 1)) { case ((avg, idx), next) => (avg + (next - avg) / idx, idx + 1) }._1
+  }
+
+
 }

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCF.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCF.scala
@@ -10,7 +10,6 @@ class RRCF(val forestParams: ForestParams, val initialData: Array[DataPoint]) {
   val trees = new Array[RRCT](forestParams.treesNum)
   val shingledData: Array[DataPoint] = initialData.sliding(forestParams.shingleSize, 1).map(x => DataPoint(x.flatMap(_.array))).toArray
   assert(shingledData.length == forestParams.samplesNum)
-  //  val shuffledInitShingles: List[DataPoint] = scala.util.Random.shuffle(shingledData)
   val shingler = new Shingler(initialData.takeRight(forestParams.shingleSize))
 
   (0 until forestParams.treesNum).par.foreach(index => trees(index) = new RRCT(shingledData))

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCT.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCT.scala
@@ -5,15 +5,13 @@ import scala.collection.mutable
 import scala.util.Random
 
 
-// TODO make RRCT care about shingles? If so, the influence of outlier on neighbour normal nodes will be diminished(?)
-// TODO
 class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
   val r = new Random()
   val treeSize: Int = initialData.length
-  val leafStorage = new mutable.ListBuffer[Leaf]()
-  private[this] val initialLeaf = Leaf(initialData(0), None) // TODO do not generate this class field
+  val leafStorage = new mutable.HashMap[DataPoint, Leaf]()
+  private[this] val initialLeaf = Leaf(initialData(0), None)
   var rootNode: Tree = initialLeaf
-  leafStorage.append(initialLeaf) // TODO change to hashtable
+  leafStorage += (initialLeaf.dataPoint -> initialLeaf)
   val reservoir: Reservoir = new TimeDecayReservoir(timeDecay, initialData)
   initialData.drop(1).foreach(initializeWithDatapoint)
 
@@ -34,7 +32,9 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
     val dataPointBoundingBox = new BoundingBox(newDataPoint)
     val commonBoundingBox = dataPointBoundingBox.union(possibleSiblingNode.boundingBox)
     val diameters = commonBoundingBox.minValues zip commonBoundingBox.maxValues map { case (min, max) => max - min }
-    val diameterCut = diameters.sum * r.nextDouble() // TODO it samples from semi-interval [0;1) but we need [0;1]
+    var randomCoeff = 0.0
+    do randomCoeff = r.nextDouble() while (randomCoeff == 0.0) // check to not make cut at 0.0
+    val diameterCut = diameters.sum * randomCoeff
     val dimensionCut = diameters.indices.view.map(i => (i, diameters.take(i + 1).sum >= diameterCut)).find(_._2).head._1
     val previousDimensionsOffset = diameters.take(dimensionCut).sum
     val coordinateCut = commonBoundingBox.minValues(dimensionCut) + diameterCut - previousDimensionsOffset
@@ -146,16 +146,16 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
 
         if (newCutNode.isDatapointInLeftSubtree(dataPoint)) {
           //Duplicate check
-          leafStorage.find(_.dataPoint.equals(dataPoint)) match {
+          leafStorage.get(dataPoint) match {
             case Some(duplicateLeaf) => newCutNode.left = duplicateLeaf; duplicateLeaf.childrenSize += 1
-            case None => leafStorage.append(newCutNode.left.asInstanceOf[Leaf])
+            case None => leafStorage += (dataPoint -> newCutNode.left.asInstanceOf[Leaf])
           }
           newCutNode.right.parent = Some(newCutNode)
         } else {
           //Duplicate check
-          leafStorage.find(_.dataPoint.equals(dataPoint)) match {
+          leafStorage.get(dataPoint) match {
             case Some(duplicateLeaf) => newCutNode.right = duplicateLeaf; duplicateLeaf.childrenSize += 1
-            case None => leafStorage.append(newCutNode.right.asInstanceOf[Leaf])
+            case None => leafStorage += (dataPoint -> newCutNode.right.asInstanceOf[Leaf])
           }
           newCutNode.left.parent = Some(newCutNode)
         }
@@ -194,8 +194,8 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
               grandParent.updateBoundingBox()
               grandParent.updateChildrenSize()
           }
-          leafStorage.remove(leafStorage.zipWithIndex.find(_._1.dataPoint.equals(dataPoint)).get._2)
       }
+      leafStorage -= dataPoint
     }
     assert(rootNode.childrenSize == treeSize - 1)
   }
@@ -207,24 +207,9 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
     * @return
     */
   private[this] def locateDatapointInTree(dataPoint: DataPoint): Leaf = {
-
-    // TODO decide what to do with older version
-    //    def locateDatapointFromNode(dataPoint: DataPoint, node: Tree): Leaf = {
-    //      node match {
-    //        case cutNode: CutNode =>
-    //          if (cutNode.isDatapointInLeftSubtree(dataPoint)) {
-    //            locateDatapointFromNode(dataPoint, cutNode.left)
-    //          } else {
-    //            locateDatapointFromNode(dataPoint, cutNode.right)
-    //          }
-    //        case leaf: Leaf => if (leaf.dataPoint.equals(dataPoint)) leaf else throw new Exception("Datapoint is not in the tree.")
-    //      }
-    //    }
-
-    //    locateDatapointFromNode(dataPoint, rootNode)
-
-    leafStorage.find(_.dataPoint.equals(dataPoint)) match {
-      case None => throw new Exception("Datapoint is not in the tree.")
+    leafStorage.get(dataPoint) match {
+      case None =>
+        throw new Exception("Datapoint is not in the tree.")
       case Some(leaf) => leaf
     }
   }

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCT.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/RRCT.scala
@@ -147,14 +147,18 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
         if (newCutNode.isDatapointInLeftSubtree(dataPoint)) {
           //Duplicate check
           leafStorage.get(dataPoint) match {
-            case Some(duplicateLeaf) => newCutNode.left = duplicateLeaf; duplicateLeaf.childrenSize += 1
+            case Some(duplicateLeaf) =>
+              newCutNode.left = duplicateLeaf
+              duplicateLeaf.childrenSize += 1
             case None => leafStorage += (dataPoint -> newCutNode.left.asInstanceOf[Leaf])
           }
           newCutNode.right.parent = Some(newCutNode)
         } else {
           //Duplicate check
           leafStorage.get(dataPoint) match {
-            case Some(duplicateLeaf) => newCutNode.right = duplicateLeaf; duplicateLeaf.childrenSize += 1
+            case Some(duplicateLeaf) =>
+              newCutNode.right = duplicateLeaf
+              duplicateLeaf.childrenSize += 1
             case None => leafStorage += (dataPoint -> newCutNode.right.asInstanceOf[Leaf])
           }
           newCutNode.left.parent = Some(newCutNode)
@@ -176,7 +180,7 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
     * @param dataPoint
     */
   private[this] def deleteDatapoint(dataPoint: DataPoint): Unit = {
-    val leaf = locateDatapointInTree(dataPoint)
+    val leaf = leafStorage(dataPoint)
     if (leaf.childrenSize > 1) { // If leaf has duplicates, simply delete one of the duplicates without changing tree
       leaf.childrenSize -= 1
       leaf.parent.foreach(_.updateChildrenSize())
@@ -200,17 +204,4 @@ class RRCT(initialData: Array[DataPoint], timeDecay: Int = 1000) {
     assert(rootNode.childrenSize == treeSize - 1)
   }
 
-  /**
-    * Given datapoint return correspoing leaf from the tree by looking into the linked list with all leafs
-    *
-    * @param dataPoint
-    * @return
-    */
-  private[this] def locateDatapointInTree(dataPoint: DataPoint): Leaf = {
-    leafStorage.get(dataPoint) match {
-      case None =>
-        throw new Exception("Datapoint is not in the tree.")
-      case Some(leaf) => leaf
-    }
-  }
 }

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/Reservoir.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/Reservoir.scala
@@ -21,7 +21,7 @@ class TimeDecayReservoir(var timeDecay: Int, storage: Array[DataPoint]) extends 
 
   // Exponentially weight points according to their timestamps
   private def scorePoint(point: TimestampedDataPoint): Double = {
-    math.pow(r nextDouble(), timeDecay / (timeDecay - point.timestamp))
+    math.pow(r.nextDouble(), timeDecay / (timeDecay - point.timestamp))
   }
 
 

--- a/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/Reservoir.scala
+++ b/demos/random_cut_demo/src/main/scala/io/hydrosphere/rrcf/impl/Reservoir.scala
@@ -21,8 +21,7 @@ class TimeDecayReservoir(var timeDecay: Int, storage: Array[DataPoint]) extends 
 
   // Exponentially weight points according to their timestamps
   private def scorePoint(point: TimestampedDataPoint): Double = {
-    // TODO increasing coefficient in the nominator will smooth  exponent?
-    math.pow(r nextDouble(), 1.0 / (timeDecay - point.timestamp))
+    math.pow(r nextDouble(), timeDecay / (timeDecay - point.timestamp))
   }
 
 

--- a/demos/random_cut_demo/src/test/scala/io/hydrosphere/rrcf/impl/RRCFTest.scala
+++ b/demos/random_cut_demo/src/test/scala/io/hydrosphere/rrcf/impl/RRCFTest.scala
@@ -1,70 +1,87 @@
-//package RRCF
-//
-//import org.scalatest.FunSuite
-//
-//import scala.util.Random
-//
-//class RRCFTest extends FunSuite {
-//
-//  test("forestOfDuplicates") {
-//    val initData = for (_ <- 0 to 100000) yield DataPoint(Array(2.0, 2.0))
-//    val forest = new RRCF(initialData = initData.toList)
-//
-//    val dataScore = forest.recieve(DataPoint(Array(2.0, 2.0)))
-//    val outlierScore = forest.recieve(DataPoint(Array(2.0, 2.0)))
-//    assert(dataScore == outlierScore)
-//    assert(dataScore == 0)
-//  }
-//
-//  test("outlierScoreIsGreater") {
-//    val r = new scala.util.Random()
-//
-//    def dataGenerator(r: Random): Array[Double] = {
-//      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
-//    }
-//
-//    def outlierGenerator(r: Random): Array[Double] = {
-//      Array(r.nextGaussian() / 6 + 3, r.nextGaussian() / 6 + 3)
-//    }
-//
-//    val initData = for (_ <- 0 to 100000) yield DataPoint(dataGenerator(r))
-//    val forest = new RRCF(initialData = initData.toList)
-//    val dataScore = forest.recieve(DataPoint(dataGenerator(r)))
-//    val outlierScore = forest.recieve(DataPoint(outlierGenerator(r)))
-//    assert(dataScore < outlierScore)
-//  }
-//
-//  test("repeatedInsertion") {
-//    val r = new scala.util.Random()
-//
-//    def dataGenerator(r: Random): Array[Double] = {
-//      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
-//    }
-//
-//    val initData = for (_ <- 0 to 100000) yield DataPoint(dataGenerator(r))
-//    val forest = new RRCF(initialData = initData.toList)
-//    (1 to 1000).foreach(_ => forest.recieve(DataPoint(dataGenerator(r))))
-//  }
-//
-//  test("repeatedDuplicateInsertionAfterRandomInit") {
-//    val r = new scala.util.Random()
-//
-//    def dataGenerator(r: Random): Array[Double] = {
-//      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
-//    }
-//
-//    def constGenerator(r: Random): Array[Double] = {
-//      Array(2.0, 2.0)
-//    }
-//
-//    def constGenerator2(r: Random): Array[Double] = {
-//      Array(3.0, 3.0)
-//    }
-//
-//    val initData = for (_ <- 0 to 100000) yield DataPoint(dataGenerator(r))
-//    val forest = new RRCF(initialData = initData.toList)
-//    (1 to 100).foreach(_ => forest.recieve(DataPoint(constGenerator(r))))
-//    (1 to 100).foreach(_ => forest.recieve(DataPoint(constGenerator2(r))))
-//  }
-//
-//}
+package io.hydrosphere.rrcf.impl
+
+import org.scalatest.FunSuite
+
+import scala.util.Random
+
+class RRCFTest extends FunSuite {
+
+  test("forestOfDuplicates") {
+
+    val fp = ForestParams()
+    val initData = for (_ <- 0 until fp.samplesNum + fp.shingleSize - 1) yield DataPoint(Array(2.0, 2.0))
+
+    val forest = new RRCF(fp, initialData = initData.toArray)
+
+    val dataScore = forest.recieve(DataPoint(Array(2.0, 2.0)))
+    val outlierScore = forest.recieve(DataPoint(Array(2.0, 2.0)))
+    assert(dataScore == outlierScore)
+    assert(dataScore == 0)
+  }
+
+  test("outlierScoreIsGreater") {
+    val r = new scala.util.Random()
+
+    def dataGenerator(r: Random): Array[Double] = {
+      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
+    }
+
+    def outlierGenerator(r: Random): Array[Double] = {
+      Array(r.nextGaussian() / 6 + 3, r.nextGaussian() / 6 + 3)
+    }
+
+    val fp = ForestParams()
+    val initData = for (_ <- 0 until fp.samplesNum + fp.shingleSize - 1) yield DataPoint(dataGenerator(r))
+    val forest = new RRCF(fp, initialData = initData.toArray)
+
+    val dataScore = forest.recieve(DataPoint(dataGenerator(r)))
+    val outlierScore = forest.recieve(DataPoint(outlierGenerator(r)))
+    assert(dataScore < outlierScore)
+  }
+
+  test("repeatedInsertion") {
+    val r = new scala.util.Random()
+
+    def dataGenerator(r: Random): Array[Double] = {
+      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
+    }
+
+    val fp = ForestParams()
+    val initData = for (_ <- 0 until fp.samplesNum + fp.shingleSize - 1) yield DataPoint(dataGenerator(r))
+    val forest = new RRCF(fp, initialData = initData.toArray)
+
+    (1 to 1000).foreach(_ => forest.recieve(DataPoint(dataGenerator(r))))
+
+  }
+
+  test("repeatedDuplicateInsertionAfterRandomInit") {
+    val r = new scala.util.Random()
+
+    def dataGenerator(r: Random): Array[Double] = {
+      Array(r.nextGaussian() / 6 + 2, r.nextGaussian() / 6 + 2)
+    }
+
+    def constGenerator(r: Random): Array[Double] = {
+      Array(2.0, 2.0)
+    }
+
+    def constGenerator2(r: Random): Array[Double] = {
+      Array(3.0, 3.0)
+    }
+
+    val fp = ForestParams()
+    val initData = for (_ <- 0 until fp.samplesNum + fp.shingleSize - 1) yield DataPoint(dataGenerator(r))
+    val forest = new RRCF(fp, initialData = initData.toArray)
+
+    (1 to 100).foreach(_ => forest.recieve(DataPoint(constGenerator(r))))
+    (1 to 100).foreach(_ => forest.recieve(DataPoint(constGenerator2(r))))
+  }
+
+  def measureTime[R](task: String)(block: => R): R = {
+    val t0 = System.nanoTime()
+    val result = block // call-by-name
+    val t1 = System.nanoTime()
+    println(s"Elapsed time ($task): \t" + (t1 - t0) / 1e9 + "s")
+    result
+  }
+}


### PR DESCRIPTION
This pull requests optimizes RRCF in terms of warmup time. 

1. RRCF now requires **n_samples  + shingle_size - 1** points instead of  **n_trees * n_samples  + shingle_size - 1**. All trees start with the same points.  Downside - they are highly correlated. However they become diverse enough only after **n_samples** points. Overall RRCF requires **2*n_samples  + shingle_size - 1** to become fully operational, but can operate after  **n_samples  + shingle_size - 1** .

2. Reservoir time decay score is changed - instead of **random(0,1)^(1/(time_decay - time_stamp))**  it is now **random(0,1)^(time_decay/(time_decay - time_stamp))**. This way trees are more diverse. Average reservoir intersection for this method is ~65%, previously it was ~82%.

3. Random Cut fixed - cut at the boundary of bounding box is now handled.  Coordinate for the cut is now sampled from (0,1) , previously [0;1)

4. Actor forest init is fixed - actor was checking newBuffer length, but was passing oldBuffer for the init.

5. RRCF tests are restored.